### PR TITLE
Add permission request for API 23

### DIFF
--- a/app/src/main/java/com/pbo/apps/dailyselfie/ImageFileHelper.java
+++ b/app/src/main/java/com/pbo/apps/dailyselfie/ImageFileHelper.java
@@ -81,7 +81,10 @@ class ImageFileHelper {
     }
 
     // Get the directory to store our images in, and create it if it doesn't already exist
-    static File getImageStorageDirectory(Context context) throws IOException  {
+    static File getImageStorageDirectory(Context context) throws IOException, SecurityException  {
+        if (!((MainActivity) context).isStoragePermissionGranted()) {
+            throw new SecurityException("App cannot run without WRITE_EXTERNAL_STORAGE permission.");
+        }
         File externalStorageDir = getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
 
         File imageDir = new File(externalStorageDir, context.getResources().getString(R.string.app_name));

--- a/app/src/main/java/com/pbo/apps/dailyselfie/MainActivity.java
+++ b/app/src/main/java/com/pbo/apps/dailyselfie/MainActivity.java
@@ -4,8 +4,10 @@ import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.StrictMode;
 import android.provider.MediaStore;
@@ -371,5 +373,20 @@ public class MainActivity extends AppCompatActivity
             mSelfieReminder = new SelfieReminder(this);
         }
         mSelfieReminder.start();
+    }
+
+    boolean isStoragePermissionGranted() {
+        if (Build.VERSION.SDK_INT >= 23) {
+            if (checkSelfPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    == PackageManager.PERMISSION_GRANTED) {
+                return true;
+            } else {
+                requestPermissions(new String[]{"android.permission.WRITE_EXTERNAL_STORAGE"}, 1);
+                return false;
+            }
+        }
+        else { //permission is automatically granted on sdk<23 upon installation
+            return true;
+        }
     }
 }


### PR DESCRIPTION
This will still throw an exception if the user doesn't give permission to the external storage, but it now gives them the option to grant permission rather than crashing outright